### PR TITLE
chore: newer os and go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine AS build_deps
+FROM golang:1.16-alpine AS build_deps
 
 RUN apk add --no-cache git
 
@@ -15,7 +15,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o webhook -ldflags '-w -extldflags "-static"' .
 
-FROM alpine:3.9
+FROM alpine:3.13
 
 RUN apk add --no-cache ca-certificates
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ns1/cert-manager-webhook-ns1
 
-go 1.13
+go 1.16
 
 require (
 	github.com/jetstack/cert-manager v0.13.0


### PR DESCRIPTION
```bash
trivy image ns1inc/cert-manager-webhook-ns1:latest
2021-07-26T15:08:40.585-0700	INFO	Using your github token
2021-07-26T15:08:43.470-0700	INFO	Detected OS: alpine
2021-07-26T15:08:43.470-0700	INFO	Detecting Alpine vulnerabilities...
2021-07-26T15:08:43.472-0700	INFO	Number of language-specific files: 1
2021-07-26T15:08:43.472-0700	INFO	Detecting gobinary vulnerabilities...
2021-07-26T15:08:43.475-0700	WARN	This OS version is no longer supported by the distribution: alpine 3.9.4
2021-07-26T15:08:43.475-0700	WARN	The vulnerability detection may be insufficient because security updates are not provided

ns1inc/cert-manager-webhook-ns1:latest (alpine 3.9.4)
=====================================================
Total: 26 (UNKNOWN: 0, LOW: 4, MEDIUM: 14, HIGH: 6, CRITICAL: 2)
...
...
```

omitted the full output happy to provide that if needed.

When this gets pushed would it be possible to give it a versioned tag or something other than `latest`? 
https://hub.docker.com/r/ns1inc/cert-manager-webhook-ns1/tags?page=1&ordering=last_updated

fwiw we use this and it works great. Works fine and dandy on k8s 1.18, happy to test more before updating the readme if you want. 