### PR TITLE
Include minutes and seconds in certificates duration fields

### DIFF
--- a/deploy/cert-manager-webhook-ns1/templates/pki.yaml
+++ b/deploy/cert-manager-webhook-ns1/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-ns1.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "cert-manager-webhook-ns1.selfSignedIssuer" . }}
   commonName: "ca.cert-manager-webhook-ns1.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-ns1.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "cert-manager-webhook-ns1.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
cert-manager rewrites the duration field to include minutes and seconds, which is seen as configuration drift by tools like argo-cd.

see https://github.com/prometheus-community/helm-charts/pull/750 and https://github.com/argoproj/argo-cd/issues/6008 for more details