### PR TITLE
Expose hostNetwork option for deployment in Helm Chart

### DIFF
--- a/deploy/cert-manager-webhook-ns1/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-ns1/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       {{- if ne .Values.priorityClassName "" }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if ne .Values.hostNetwork false }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/cert-manager-webhook-ns1/values.yaml
+++ b/deploy/cert-manager-webhook-ns1/values.yaml
@@ -46,3 +46,5 @@ tolerations: []
 affinity: {}
 
 priorityClassName: ""
+
+hostNetwork: false


### PR DESCRIPTION
This adds the ability to specify `hostNetwork` in the helm Chart so that it can be added to the `deployment`'s spec.

Solves the problem of an unreachable `apiservice` as described in https://github.com/ns1/cert-manager-webhook-ns1/issues/9 for an EKS deploy.