### PR TITLE
Build for arm64

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,20 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    env:       
+      DOCKER_TARGET_PLATFORM: linux/arm64
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,19 +2,44 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ master ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ master ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-
-  build:
-
+  build-and-push-image:
     runs-on: ubuntu-latest
     env:       
       DOCKER_TARGET_PLATFORM: linux/arm64
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+          labels: ${{ steps.vars.outputs.sha_short }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM build_deps AS build
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o webhook -ldflags '-w -extldflags "-static"' .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o webhook -ldflags '-w -extldflags "-static"' .
 
 FROM alpine:3.18
 


### PR DESCRIPTION
I deployed an arm-based k3s cluster and wanted to continue to use this plugin but ran into a compatibility issue. This simply builds the Go package for arm64 (I suspect you all would want to handle this differently). Also, the included Github workflow builds the container for arm64, also.

In my helm values I changed the repo location to my Github package. I am able to issue LE certs now. Running pod describe, if it's helpful:

```
Name:             cert-manager-ns1-cert-manager-webhook-ns1-6b58744f5-qh7wk
Namespace:        cert-manager
Priority:         0
Service Account:  cert-manager-ns1-cert-manager-webhook-ns1
Node:             re.dac.ted/re.da.ct.ed
Start Time:       Mon, 26 Jun 2023 13:21:14 -0400
Labels:           app=cert-manager-webhook-ns1
                  pod-template-hash=6b58744f5
                  release=cert-manager-ns1
Annotations:      <none>
Status:           Running
IP:               10.42.4.7
IPs:
  IP:           10.42.4.7
Controlled By:  ReplicaSet/cert-manager-ns1-cert-manager-webhook-ns1-6b58744f5
Containers:
  cert-manager-webhook-ns1:
    Container ID:  containerd://abfdb337a2dc4f448e6d118e974c31d508d0836760b3e7b278767fcdc500bd29
    Image:         ghcr.io/zchef2k/cert-manager-webhook-ns1:latest
    Image ID:      ghcr.io/zchef2k/cert-manager-webhook-ns1@sha256:d9eb39049535070b497767c2332bdf21fa2f8b94865d05a7a6acafe182ec6241
    Port:          8443/TCP
    Host Port:     0/TCP
    Args:
      --secure-port=8443
      --tls-cert-file=/tls/tls.crt
      --tls-private-key-file=/tls/tls.key
    State:          Running
      Started:      Mon, 26 Jun 2023 13:21:17 -0400
    Ready:          True
    Restart Count:  0
    Liveness:       http-get https://:https/healthz delay=0s timeout=1s period=10s #success=1 #failure=3
    Readiness:      http-get https://:https/healthz delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:
      GROUP_NAME:  acme.nsone.net
    Mounts:
      /tls from certs (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-trh5p (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  certs:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  cert-manager-ns1-cert-manager-webhook-ns1-webhook-tls
    Optional:    false
  kube-api-access-trh5p:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:                      <none>
```